### PR TITLE
add support no auth SMTP

### DIFF
--- a/Controller/Adminhtml/Test/Index.php
+++ b/Controller/Adminhtml/Test/Index.php
@@ -48,11 +48,12 @@ class Index extends Action
         $name = 'MagePal Gmail Smtp App Test';
         $username = $request->getPost('username');
         $password = $request->getPost('password');
+        $auth = strtolower($request->getPost('auth'));
 
         //if default view 
         //see https://github.com/magento/magento2/issues/3019
         if(!$request->getParam('store', false)){
-            if(empty($username) || empty($password)){
+            if($auth != 'none' && (empty($username) || empty($password))) {
                 $this->getResponse()->setBody(__('Please enter a valid username/password'));
                 return;
             }
@@ -68,11 +69,14 @@ class Index extends Action
 
         $smtpConf = array(
             'name' => $request->getPost('name'),
-            'auth' => strtolower($request->getPost('auth')),
-            'username' => $username,
-            'password' => $password,
             'port' => $request->getPost('smtpport')
         );
+        if ($auth != 'none') {
+            $smtpConf['auth'] = $auth;
+            $smtpConf['username'] = $username;
+            $smtpConf['password'] = $password;
+
+        }
 
         $ssl = $request->getPost('ssl');
         if ($ssl != 'none') {

--- a/Model/Transport.php
+++ b/Model/Transport.php
@@ -52,11 +52,14 @@ class Transport extends \Zend_Mail_Transport_Smtp implements \Magento\Framework\
         //set config
         $smtpConf = [
            'name' => $dataHelper->getConfigName(),
-           'auth' => strtolower($dataHelper->getConfigAuth()),
-           'username' => $dataHelper->getConfigUsername(),
-           'password' => $dataHelper->getConfigPassword(),
            'port' => $dataHelper->getConfigSmtpPort(),
         ];
+        $auth = strtolower($dataHelper->getConfigAuth());
+        if ($auth != 'none') {
+            $smtpConf['auth'] = $auth;
+            $smtpConf['username'] = $dataHelper->getConfigUsername();
+            $smtpConf['password'] = $dataHelper->getConfigPassword();
+        }
 
         $ssl = $dataHelper->getConfigSsl();
         if ($ssl != 'none') {


### PR DESCRIPTION
In local development machine, I use https://github.com/ChangemakerStudios/Papercut as mail catcher.
Some private SMTP also use IP base auth.
In this cases the auth type, user, password is not needed.