### PR TITLE
Allow updating to Magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/module-backend": "100.0.*|100.1.*|100.2.*",
-        "magento/framework": "100.0.*|100.1.*|100.2.*"
+        "magento/framework": "100.0.*|100.1.*|100.2.*|101.0.*"
     },
     "type": "magento2-module",
     "version": "1.4.6",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "magento/framework": "100.0.*|100.1.*|100.2.*|101.0.*"
     },
     "type": "magento2-module",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
Allow updating to Magento 2.2 (using Magento Framework version 101.0.0)